### PR TITLE
Fix: Remove spaces from 'usn' field to prevent API call errors

### DIFF
--- a/lib/api/attendance_api.dart
+++ b/lib/api/attendance_api.dart
@@ -18,7 +18,7 @@ class API extends ChangeNotifier {
 
   void getSharedPref() async {
     SharedPreferences pref = await SharedPreferences.getInstance();
-    usn = pref.getString('usn');
+    usn = pref.getString('usn')?.replaceAll(' ', '');
     yyyy = pref.getString('yyyy');
     mm = pref.getString('mm');
     dd = pref.getString('dd');


### PR DESCRIPTION
This pull request addresses an issue where the 'usn' field was allowing spaces, leading to errors in API calls. 

Changes Made:
In the getSharedPref method, added code to remove spaces from the 'usn' field using the replaceAll method.